### PR TITLE
Fix order of arguments in ply write

### DIFF
--- a/src/io/ply.jl
+++ b/src/io/ply.jl
@@ -8,7 +8,7 @@ immutable FileEnding{Disambiguated_Ending}
 end
 const ply_binary = FileEnding{:ply_binary}(:ply, b"ply\nformat binary_little_endian 1.0\n")
 
-function Base.write{M <: Mesh}(msh::M, fn::File{:ply_binary})
+function Base.write(fn::File{:ply_binary}, msh::Mesh)
 
     vts = msh[Point3{Float32}]
     fcs = msh[Face3{Int32, -1}]
@@ -38,7 +38,7 @@ end
 const ply_ascii = FileEnding{:ply_binary}(:ply, b"ply\nformat binary_little_endian 1.0\n")
 
 
-function Base.write{M <: Mesh}(msh::M, fn::File{:ply_ascii})
+function Base.write(fn::File{:ply_ascii}, msh::Mesh)
 
     vts = msh[Point3{Float32}]
     fcs = msh[Face3{Int32, -1}]
@@ -114,7 +114,7 @@ function read_ascii_ply(io::IO, typ=GLNormalMesh)
             fcs[i]  = FaceType(Face3{FaceEltype, -1}(line)) # line looks like: "3 0 1 2"
         elseif len == 4
             fcs[i]  = FaceType(Face4{FaceEltype, -1}(line))
-        else 
+        else
             error("face type with length $len is not supported yet")
         end
     end


### PR DESCRIPTION
Fixes the order of arguments for ply write to correspond to https://github.com/JuliaIO/FileIO.jl/blob/master/src/core.jl#L37

(No need for parametrisation of M since the function will be specialized for each type anyway)