### PR TITLE
Add `save(f::Stream{format"STL_BINARY"}, msh::AbstractMesh)`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.4
+  - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/io/stl.jl
+++ b/src/io/stl.jl
@@ -15,7 +15,7 @@ function save(f::Stream{format"STL_ASCII"}, msh::AbstractMesh)
     # write the data
     for i = 1:nF
         f = fcs[i]
-        n = normals[i] # TODO: properly compute normal(f)
+        n = normals[f][1] # TODO: properly compute normal(f)
         v1, v2, v3 = vts[f]
         @printf io "  facet normal %e %e %e\n" n[1] n[2] n[3]
         write(io,"    outer loop\n")
@@ -80,8 +80,8 @@ function load(fs::Stream{format"STL_BINARY"}, MeshType=GLNormalMesh)
     while !eof(io)
         faces[i+1]      = Face{3, Int, -1}(i*3, i*3+1, i*3+2)
         normals[i*3+1]  = NormalType(read(io, Float32), read(io, Float32), read(io, Float32))
-        normals[i*3+2]  = normals[i*3+2] # hurts, but we need per vertex normals
-        normals[i*3+3]  = normals[i*3+2]
+        normals[i*3+2]  = normals[i*3+1] # hurts, but we need per vertex normals
+        normals[i*3+3]  = normals[i*3+1]
         vertices[i*3+1] = VertexType(read(io, Float32), read(io, Float32), read(io, Float32))
         vertices[i*3+2] = VertexType(read(io, Float32), read(io, Float32), read(io, Float32))
         vertices[i*3+3] = VertexType(read(io, Float32), read(io, Float32), read(io, Float32))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,8 +30,8 @@ facts("MeshIO") do
 			save(File(format"STL_ASCII", joinpath(tmpdir, "test.stl")), mesh)
 			mesh_loaded = GLPlainMesh(joinpath(tmpdir, "test.stl"))
 			#@fact mesh_loaded --> mesh
-			#save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), mesh)
-			#mesh_loaded = GLPlainMesh(joinpath(tmpdir, "test.stl"))
+			save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), mesh)
+			mesh_loaded = GLNormalMesh(joinpath(tmpdir, "test.stl"))
 			#@fact mesh_loaded --> mesh
 		end
 	end
@@ -50,6 +50,15 @@ facts("MeshIO") do
 			@fact length(vertices(msh)) --> 2484
 			@fact length(normals(msh)) --> 2484
 
+            mktempdir() do tmpdir
+                save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), msh)
+                msh1 = load(joinpath(tmpdir, "test.stl"))
+                @fact typeof(msh1) --> GLNormalMesh
+                @fact faces(msh) --> faces(msh1)
+                @fact vertices(msh) --> vertices(msh1)
+                @fact normals(msh) --> normals(msh1)
+            end
+            
 			msh = load(joinpath(tf, "binary_stl_from_solidworks.STL"))
 			@fact typeof(msh) --> GLNormalMesh
 			@fact length(faces(msh)) --> 12


### PR DESCRIPTION
~~Add `exportBinaryStl` function and rename `exportStl` to `exportAsciiSTL` for consistency, this has been moved from JuliaGeometry/Meshes.jl/pull/41. How about test of the implementation, the STL module do not seem to be hooked up to the package yet?~~
Add `save(f::Stream{format"STL_BINARY"}, msh::AbstractMesh)` + test, bug fixes in loading and saving stl files and activate the CI to test both 0.4 and nightly