### PR TITLE
Fix triangulate -> decompose depwarns on GeometryTypes

### DIFF
--- a/src/io/2dm.jl
+++ b/src/io/2dm.jl
@@ -15,7 +15,7 @@ function load(st::Stream{format"2DM"}, MeshType=GLNormalMesh)
             elseif w[1] == "E3T"
                 push!(faces, Face{3, Cuint, 0}(w[3:5]))
             elseif w[1] == "E4Q"
-                push!(faces, triangulate(FT, Face{4, Cuint, 0}(w[3:6]))...)
+                push!(faces, decompose(FT, Face{4, Cuint, 0}(w[3:6]))...)
             else
                 continue
             end

--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -35,7 +35,7 @@ function load{MT <: AbstractMesh}(io::Stream{format"OBJ"}, MeshType::Type{MT}=GL
                     if length(lines) == 3
                         push!(faces(mesh), Triangle{UInt32}(lines))
                     elseif length(lines) == 4
-                        push!(faces(mesh), triangulate(eltype(faces(mesh)), Face{4, UInt32, 0}(lines))...)
+                        push!(faces(mesh), decompose(eltype(faces(mesh)), Face{4, UInt32, 0}(lines))...)
                     end
                     continue
                 end

--- a/src/io/off.jl
+++ b/src/io/off.jl
@@ -61,7 +61,7 @@ function load(st::Stream{format"OFF"}, MeshType=GLNormalMesh)
             if facelen == 3
                 push!(fcs, GLTriangle(splitted))
             elseif facelen == 4
-                push!(fcs, triangulate(FT, Face{4, Cuint, -1}(splitted))...)
+                push!(fcs, decompose(FT, Face{4, Cuint, -1}(splitted))...)
             end
             continue
         elseif !found_counts && isdigit(split(txt)[1]) # vertex and face counts

--- a/src/io/ply.jl
+++ b/src/io/ply.jl
@@ -92,7 +92,7 @@ function load(fs::Stream{format"PLY_ASCII"}, MeshType=GLNormalMesh)
         if len == 3
             push!(fcs, Face{len, FaceEltype, -1}(line)) # line looks like: "3 0 1 3"
         elseif len == 4
-            push!(fcs, triangulate(FaceType, Face{len, FaceEltype, -1}(line))...) # line looks like: "4 0 1 2 3"
+            push!(fcs, decompose(FaceType, Face{len, FaceEltype, -1}(line))...) # line looks like: "4 0 1 2 3"
         end
     end
 


### PR DESCRIPTION
Shouldn't be merged until after GeometryTypes v0.1.0 is tagged. See: https://github.com/JuliaGeometry/GeometryTypes.jl/issues/25