### PR TITLE
fixes for 0.5

### DIFF
--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -7,7 +7,7 @@ using Compat
 import FileIO
 
 import FileIO: DataFormat, @format_str, Stream, File, filename, stream, skipmagic
-import Base: writemime, call
+import Base: writemime
 
 
 
@@ -24,7 +24,5 @@ end
 save{format}(fn::File{format}, msh::AbstractMesh) = open(fn, "w") do s
 	save(s, msh)
 end
-
-call{M <: AbstractMesh}(m::Type{M}, f::AbstractString) = FileIO.load(f, m)
 
 end # module

--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -63,8 +63,9 @@ function load{MT <: AbstractMesh}(io::Stream{format"OBJ"}, MeshType::Type{MT}=GL
     return MT(HomogenousMesh(attributes))
 end
 
-immutable SplitFunctor <: Base.Func{1}
-    seperator::ASCIIString
+
+immutable SplitFunctor
+    seperator::Compat.UTF8String
 end
 call(s::SplitFunctor, array) = split(array, s.seperator)
 

--- a/src/io/ply.jl
+++ b/src/io/ply.jl
@@ -58,7 +58,7 @@ function load(fs::Stream{format"PLY_ASCII"}, MeshType=GLNormalMesh)
     nV = 0
     nF = 0
 
-    properties = ASCIIString[]
+    properties = Compat.UTF8String[]
 
     # read the header
     line = readline(io)

--- a/src/io/stl.jl
+++ b/src/io/stl.jl
@@ -51,7 +51,7 @@ function save(f::Stream{format"STL_BINARY"}, mesh::AbstractMesh)
         n = normals[f][1] # TODO: properly compute normal(f)
         v1, v2, v3 = vts[f]
         for j=1:3; write(io, n[j]); end # write normal
-        
+
         for v in [v1, v2, v3]
             for j = 1:3
                 write(io, v[j]) # write vertex coordinates
@@ -66,7 +66,7 @@ function load(fs::Stream{format"STL_BINARY"}, MeshType=GLNormalMesh)
     #Binary STL
     #https://en.wikipedia.org/wiki/STL_%28file_format%29#Binary_STL
     io = stream(fs)
-    readbytes(io, 80) # throw out header
+    read(io, 80) # throw out header
 
     triangle_count = read(io, UInt32)
     FaceType    = facetype(MeshType)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,52 +3,52 @@ using FileIO, FactCheck, GeometryTypes
 const tf = joinpath(dirname(@__FILE__), "testfiles")
 
 facts("MeshIO") do
-	dirlen 	= 1f0
-	baselen = 0.02f0
-	mesh 	= [
-		AABB{Float32}(Vec3f0(baselen), Vec3f0(dirlen, baselen, baselen)),
-		AABB{Float32}(Vec3f0(baselen), Vec3f0(baselen, dirlen, baselen)),
-		AABB{Float32}(Vec3f0(baselen), Vec3f0(baselen, baselen, dirlen))
-	]
-	mesh = merge(map(GLPlainMesh, mesh))
-	mktempdir() do tmpdir
-		for ext in ["2dm", "off"]
-			context("load save $ext") do
-				save(joinpath(tmpdir, "test.$ext"), mesh)
-				mesh_loaded = GLPlainMesh(joinpath(tmpdir, "test.$ext"))
-				@fact mesh_loaded --> mesh
-			end
-		end
-		context("PLY ascii and binary") do
-			f = File(format"PLY_ASCII", joinpath(tmpdir, "test.ply"))
-			save(f, mesh)
-			mesh_loaded = GLPlainMesh(joinpath(tmpdir, "test.ply"))
-			@fact mesh_loaded --> mesh
-			save(File(format"PLY_BINARY", joinpath(tmpdir, "test.ply")), mesh)
-		end
-		context("STL ascii and binary") do
-			save(File(format"STL_ASCII", joinpath(tmpdir, "test.stl")), mesh)
-			mesh_loaded = GLPlainMesh(joinpath(tmpdir, "test.stl"))
-			#@fact mesh_loaded --> mesh
-			save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), mesh)
-			mesh_loaded = GLNormalMesh(joinpath(tmpdir, "test.stl"))
-			#@fact mesh_loaded --> mesh
-		end
-	end
-	context("Real world files") do
+    dirlen     = 1f0
+    baselen = 0.02f0
+    mesh     = [
+        AABB{Float32}(Vec3f0(baselen), Vec3f0(dirlen, baselen, baselen)),
+        AABB{Float32}(Vec3f0(baselen), Vec3f0(baselen, dirlen, baselen)),
+        AABB{Float32}(Vec3f0(baselen), Vec3f0(baselen, baselen, dirlen))
+    ]
+    mesh = merge(map(GLPlainMesh, mesh))
+    mktempdir() do tmpdir
+        for ext in ["2dm", "off"]
+            context("load save $ext") do
+                save(joinpath(tmpdir, "test.$ext"), mesh)
+                mesh_loaded = load(joinpath(tmpdir, "test.$ext"), GLPlainMesh)
+                @fact mesh_loaded --> mesh
+            end
+        end
+        context("PLY ascii and binary") do
+            f = File(format"PLY_ASCII", joinpath(tmpdir, "test.ply"))
+            save(f, mesh)
+            mesh_loaded = load(joinpath(tmpdir, "test.ply"), GLPlainMesh)
+            @fact mesh_loaded --> mesh
+            save(File(format"PLY_BINARY", joinpath(tmpdir, "test.ply")), mesh)
+        end
+        context("STL ascii and binary") do
+            save(File(format"STL_ASCII", joinpath(tmpdir, "test.stl")), mesh)
+            mesh_loaded = load(joinpath(tmpdir, "test.stl"), GLPlainMesh)
+            #@fact mesh_loaded --> mesh
+            save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), mesh)
+            mesh_loaded = load(joinpath(tmpdir, "test.stl"), GLNormalMesh)
+            #@fact mesh_loaded --> mesh
+        end
+    end
+    context("Real world files") do
 
-		context("STL") do
-			msh = load(joinpath(tf, "ascii.stl"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 12
-			@fact length(vertices(msh)) --> 36
-			@fact length(normals(msh)) --> 36
+        context("STL") do
+            msh = load(joinpath(tf, "ascii.stl"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 12
+            @fact length(vertices(msh)) --> 36
+            @fact length(normals(msh)) --> 36
 
-			msh = load(joinpath(tf, "binary.stl"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 828
-			@fact length(vertices(msh)) --> 2484
-			@fact length(normals(msh)) --> 2484
+            msh = load(joinpath(tf, "binary.stl"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 828
+            @fact length(vertices(msh)) --> 2484
+            @fact length(normals(msh)) --> 2484
 
             mktempdir() do tmpdir
                 save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), msh)
@@ -58,86 +58,87 @@ facts("MeshIO") do
                 @fact vertices(msh) --> vertices(msh1)
                 @fact normals(msh) --> normals(msh1)
             end
-            
-			msh = load(joinpath(tf, "binary_stl_from_solidworks.STL"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 12
-			@fact length(vertices(msh)) --> 36
 
-			# STL Import
-			msh = load(joinpath(tf, "cube_binary.stl"))
-			@fact length(vertices(msh)) -->36
-			@fact length(faces(msh)) --> 12
+            msh = load(joinpath(tf, "binary_stl_from_solidworks.STL"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 12
+            @fact length(vertices(msh)) --> 36
+
+            # STL Import
+            msh = load(joinpath(tf, "cube_binary.stl"))
+            @fact length(vertices(msh)) -->36
+            @fact length(faces(msh)) --> 12
 
 
-			msh = load(joinpath(tf, "cube.stl"))
-			@fact length(vertices(msh)) --> 36
-			@fact length(faces(msh)) --> 12
+            msh = load(joinpath(tf, "cube.stl"))
+            @fact length(vertices(msh)) --> 36
+            @fact length(faces(msh)) --> 12
 
-		end
-		context("PLY") do
-			msh = load(joinpath(tf, "ascii.ply"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 36
-			@fact length(vertices(msh)) --> 72
-			@fact length(normals(msh)) --> 72
-			#msh = load(joinpath(tf, "binary.ply")) # still missing
-			#@fact typeof(msh) --> GLNormalMesh
-			#println(msh)
-			msh = load(joinpath(tf, "cube.ply")) # quads
-			@fact length(vertices(msh)) --> 24
-			@fact length(faces(msh)) --> 12
-		end
-		context("OFF") do
-			msh = load(joinpath(tf, "test.off"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 28
-			@fact length(vertices(msh)) --> 20
-			@fact length(normals(msh)) --> 20
+        end
+        context("PLY") do
+            msh = load(joinpath(tf, "ascii.ply"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 36
+            @fact length(vertices(msh)) --> 72
+            @fact length(normals(msh)) --> 72
+            #msh = load(joinpath(tf, "binary.ply")) # still missing
+            #@fact typeof(msh) --> GLNormalMesh
+            #println(msh)
+            msh = load(joinpath(tf, "cube.ply")) # quads
+            @fact length(vertices(msh)) --> 24
+            @fact length(faces(msh)) --> 12
+        end
+        context("OFF") do
+            msh = load(joinpath(tf, "test.off"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 28
+            @fact length(vertices(msh)) --> 20
+            @fact length(normals(msh)) --> 20
 
-			msh = load(joinpath(tf, "test2.off"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 810
-			@fact length(vertices(msh)) --> 405
-			@fact length(normals(msh)) --> 405
+            msh = load(joinpath(tf, "test2.off"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 810
+            @fact length(vertices(msh)) --> 405
+            @fact length(normals(msh)) --> 405
 
-			msh = load(joinpath(tf, "cube.off"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 12
-			@fact length(vertices(msh)) --> 8
+            msh = load(joinpath(tf, "cube.off"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 12
+            @fact length(vertices(msh)) --> 8
 
-		end
-		context("OBJ") do
-			msh = load(joinpath(tf, "test.obj"))
-			@fact typeof(msh) --> GLNormalMesh
-			@fact length(faces(msh)) --> 3954
-			@fact length(vertices(msh)) --> 2248
-			@fact length(normals(msh)) --> 2248
+        end
+        context("OBJ") do
+            msh = load(joinpath(tf, "test.obj"))
+            @fact typeof(msh) --> GLNormalMesh
+            @fact length(faces(msh)) --> 3954
+            @fact length(vertices(msh)) --> 2248
+            @fact length(normals(msh)) --> 2248
 
-			msh = load(joinpath(tf, "cube.obj")) # quads
-			@fact length(faces(msh)) --> 12
-			@fact length(vertices(msh)) --> 8
+            msh = load(joinpath(tf, "cube.obj")) # quads
+            @fact length(faces(msh)) --> 12
+            @fact length(vertices(msh)) --> 8
 
-		end
-		context("2DM") do
-			msh = load(joinpath(tf, "test.2dm"))
-			@fact typeof(msh) --> GLNormalMesh
-			#@fact length(faces(msh)) --> 3954
-			#@fact length(vertices(msh)) --> 2248
-			#@fact length(normals(msh)) --> 2248
-		end
-	end
+        end
+        context("2DM") do
+            msh = load(joinpath(tf, "test.2dm"))
+            @fact typeof(msh) --> GLNormalMesh
+            #@fact length(faces(msh)) --> 3954
+            #@fact length(vertices(msh)) --> 2248
+            #@fact length(normals(msh)) --> 2248
+        end
+    end
 end
 
 
 
 
 if false
-	#using GLPlot, GLVisualize, GLAbstraction, FileIO
-	tf = Pkg.dir("MeshIO", "test", "testfiles")
-	meshes = [visualize(load(joinpath(tf, name))) for name in readdir(tf)];
-	meshes = convert(Matrix{RenderObject}, reshape(meshes, (7, 2)));
-	glplot(meshes);
+    #using GLVisualize, GLAbstraction, FileIO
+    w = glscreen()
+    meshes = [visualize(load(joinpath(tf, name))) for name in readdir(tf)];
+    meshes = convert(Matrix{Context}, reshape(meshes, (7, 2)));
+    view(visualize(meshes))
+    renderloop(w)
 end
 #=
 


### PR DESCRIPTION
I decided to remove the `MeshType(::String)` constructor, since it doesn't seem to work on 0.5 and doesn't really offer much over `load(::String, MeshType)`