### PR TITLE
triangulate polygonal faces with any number of vertices when loading OBJ

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,6 +118,10 @@ facts("MeshIO") do
             @fact length(faces(msh)) --> 12
             @fact length(vertices(msh)) --> 8
 
+            msh = load(joinpath(tf, "polygonal_face.obj"))
+            @fact length(faces(msh)) --> 4
+            @fact length(vertices(msh)) --> 6
+
         end
         context("2DM") do
             msh = load(joinpath(tf, "test.2dm"))

--- a/test/testfiles/polygonal_face.obj
+++ b/test/testfiles/polygonal_face.obj
@@ -1,0 +1,9 @@
+# This mesh contains a single face with 6 vertices, which we can use to verify
+# automatic triangulation of polygonal faces.
+v 0.0 0.0 0.0
+v 1.0 0.0 0.0
+v 1.5 0.5 0.0
+v 1.0 1.0 0.0
+v 0.5 1.5 0.0
+v 0.0 1.0 0.0
+f 1 2 3 4 5 6


### PR DESCRIPTION
`.obj` files can contain faces with an arbitrary number of vertices. This patch changes the `obj` loader to triangulate any polygonal faces when loading the mesh. 

Note that this calls `decompose()` even when it's not strictly necessary (when the face is already a triangle). But the `@generated` `decompose` method for such a case compiles down to just a single call to the constructor of the new `Face` type, so there shouldn't be any additional cost for doing so. 