### PR TITLE
Fix if-else sequence

### DIFF
--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -34,10 +34,10 @@ function load{MT <: AbstractMesh}(io::Stream{format"OBJ"}, MeshType::Type{MT} = 
                     error("Unknown UVW coordinate: $lines")
                 end
             elseif "f" == command #mesh always has faces
-                if any(x->contains(x, "/"), lines)
-                    fs = process_face_uv_or_normal(lines)
-                elseif any(x->contains(x, "//"), lines)
+                if any(x->contains(x, "//"), lines)
                     fs = process_face_normal(lines)
+                elseif any(x->contains(x, "/"), lines)
+                    fs = process_face_uv_or_normal(lines)
                 else
                     push!(f, triangulated_faces(Tf, lines)...)
                     continue


### PR DESCRIPTION
Since `contains("f 1//1 2//2 3//3", "/")` returns true, the face normal(`process_face_normal`) block may never be executed. I don't know whether this will affect other cases, @SimonDanisch please give a review at your convenience. 😉 
  
  