### PR TITLE
fix all deprecation warnings on julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
+# matrix:
+#   allow_failures:
+#     - julia: nightly
 
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7-alpha
+julia 0.7-rc1
 
 GeometryTypes 0.4
 ColorTypes

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-alpha
 
 GeometryTypes 0.4
 ColorTypes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
-matrix:
-  allow_failures:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+# matrix:
+#   allow_failures:
+#   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+#   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -4,6 +4,7 @@ module MeshIO
 using GeometryTypes
 using GeometryTypes: raw
 using ColorTypes
+using Printf
 import FileIO
 
 import FileIO: DataFormat, @format_str, Stream, File, filename, stream, skipmagic
@@ -17,11 +18,11 @@ include("io/stl.jl")
 include("io/obj.jl")
 include("io/2dm.jl")
 
-load{format}(fn::File{format}, MeshType=GLNormalMesh) = open(fn) do s
+load(fn::File{format}, MeshType=GLNormalMesh) where {format} = open(fn) do s
     skipmagic(s)
     load(s, MeshType)
 end
-save{format}(fn::File{format}, msh::AbstractMesh) = open(fn, "w") do s
+save(fn::File{format}, msh::AbstractMesh) where {format} = open(fn, "w") do s
     save(s, msh)
 end
 

--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -1,4 +1,3 @@
-__precompile__(true)
 module MeshIO
 
 using GeometryTypes

--- a/src/io/off.jl
+++ b/src/io/off.jl
@@ -23,8 +23,8 @@ function save(str::Stream{format"OFF"}, msh::AbstractMesh)
         f = fcs[i]
         c = isa(cs, Array) ? RGBA{Float32}(cs[i]) : cs
         facelen = length(f)
-        println(io, 
-            facelen, " ", join(raw.(ZeroIndex.(f)), " "), " ", 
+        println(io,
+            facelen, " ", join(raw.(ZeroIndex.(f)), " "), " ",
             join((red(c), green(c), blue(c), alpha(c)), " ")
         )
     end
@@ -56,7 +56,7 @@ function load(st::Stream{format"OFF"}, MeshType=GLNormalMesh)
             continue
         elseif found_counts # read faces
             splitted = split(txt)
-            facelen  = parse(Int, shift!(splitted))
+            facelen  = parse(Int, popfirst!(splitted))
             if facelen == 3
                 push!(fcs, GLTriangle(reinterpret(ZeroIndex{Cuint}, parse.(Cuint, splitted[1:3]))))
             elseif facelen == 4
@@ -67,7 +67,7 @@ function load(st::Stream{format"OFF"}, MeshType=GLNormalMesh)
             counts = Int[parse(Int, s) for s in split(txt)]
             nV = counts[1]
             nF = counts[2]
-            vts = Array{VT}(nV)
+            vts = Array{VT}(undef, nV)
             found_counts = true
         end
     end

--- a/src/io/ply.jl
+++ b/src/io/ply.jl
@@ -77,8 +77,8 @@ function load(fs::Stream{format"PLY_ASCII"}, MeshType=GLNormalMesh)
     FaceType    = facetype(MeshType)
     FaceEltype  = eltype(FaceType)
 
-    vts         = Array{VertexType}(nV)
-    #fcs         = Array{FaceType}(nF)
+    vts         = Array{VertexType}(undef, nV)
+    #fcs         = Array{FaceType}(undef, nF)
     fcs         = FaceType[]
 
     # read the data
@@ -88,7 +88,7 @@ function load(fs::Stream{format"PLY_ASCII"}, MeshType=GLNormalMesh)
 
     for i = 1:nF
         line    = split(readline(io))
-        len     = parse(Int, shift!(line))
+        len     = parse(Int, popfirst!(line))
         if len == 3
             push!(fcs, Face{3, FaceEltype}(reinterpret(ZeroIndex{Int}, parse.(Int, line)))) # line looks like: "3 0 1 3"
         elseif len == 4

--- a/src/io/stl.jl
+++ b/src/io/stl.jl
@@ -70,9 +70,9 @@ function load(fs::Stream{format"STL_BINARY"}, MeshType=GLNormalMesh)
     VertexType  = vertextype(MeshType)
     NormalType  = normaltype(MeshType)
 
-    faces       = Array{FaceType}(triangle_count)
-    vertices    = Array{VertexType}(triangle_count*3)
-    normals     = Array{NormalType}(triangle_count*3)
+    faces       = Array{FaceType}(undef, triangle_count)
+    vertices    = Array{VertexType}(undef, triangle_count*3)
+    normals     = Array{NormalType}(undef, triangle_count*3)
     i = 0
     while !eof(io)
         faces[i+1]      = Face{3, ZeroIndex{Int}}(i*3+1, i*3+2, i*3+3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,14 @@ using FileIO, GeometryTypes
 using Test
 const tf = joinpath(dirname(@__FILE__), "testfiles")
 
+function test_face_indices(mesh)
+    for face in faces(mesh)
+        for index in face
+            @test firstindex(vertices(mesh)) <= index <= lastindex(vertices(mesh))
+        end
+    end
+end
+
 @testset "MeshIO" begin
     dirlen = 1f0
     baselen = 0.02f0
@@ -43,12 +51,14 @@ const tf = joinpath(dirname(@__FILE__), "testfiles")
             @test length(faces(msh)) == 12
             @test length(vertices(msh)) == 36
             @test length(normals(msh)) == 36
+            test_face_indices(msh)
 
             msh = load(joinpath(tf, "binary.stl"))
             @test typeof(msh) == GLNormalMesh
             @test length(faces(msh)) == 828
             @test length(vertices(msh)) == 2484
             @test length(normals(msh)) == 2484
+            test_face_indices(msh)
 
             mktempdir() do tmpdir
                 save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), msh)
@@ -63,22 +73,26 @@ const tf = joinpath(dirname(@__FILE__), "testfiles")
             @test typeof(msh) == GLNormalMesh
             @test length(faces(msh)) == 12
             @test length(vertices(msh)) == 36
+            test_face_indices(msh)
 
             # STL Import
             msh = load(joinpath(tf, "cube_binary.stl"))
             @test length(vertices(msh)) == 36
             @test length(faces(msh)) == 12
+            test_face_indices(msh)
 
 
             msh = load(joinpath(tf, "cube.stl"))
             @test length(vertices(msh)) == 36
             @test length(faces(msh)) == 12
+            test_face_indices(msh)
 
         end
         @testset "PLY" begin
             msh = load(joinpath(tf, "ascii.ply"))
             @test typeof(msh) == GLNormalMesh
             @test length(faces(msh)) == 36
+            test_face_indices(msh)
             @test length(vertices(msh)) == 72
             @test length(normals(msh)) == 72
             #msh = load(joinpath(tf, "binary.ply")) # still missing
@@ -87,6 +101,7 @@ const tf = joinpath(dirname(@__FILE__), "testfiles")
             msh = load(joinpath(tf, "cube.ply")) # quads
             @test length(vertices(msh)) == 24
             @test length(faces(msh)) == 12
+            test_face_indices(msh)
         end
         @testset "OFF" begin
             msh = load(joinpath(tf, "test.off"))
@@ -94,17 +109,20 @@ const tf = joinpath(dirname(@__FILE__), "testfiles")
             @test length(faces(msh)) == 28
             @test length(vertices(msh)) == 20
             @test length(normals(msh)) == 20
+            test_face_indices(msh)
 
             msh = load(joinpath(tf, "test2.off"))
             @test typeof(msh) == GLNormalMesh
             @test length(faces(msh)) == 810
             @test length(vertices(msh)) == 405
             @test length(normals(msh)) == 405
+            test_face_indices(msh)
 
             msh = load(joinpath(tf, "cube.off"))
             @test typeof(msh) == GLNormalMesh
             @test length(faces(msh)) == 12
             @test length(vertices(msh)) == 8
+            test_face_indices(msh)
 
         end
         @testset "OBJ" begin
@@ -113,23 +131,28 @@ const tf = joinpath(dirname(@__FILE__), "testfiles")
             @test length(faces(msh)) == 3954
             @test length(vertices(msh)) == 2248
             @test length(normals(msh)) == 2248
+            test_face_indices(msh)
 
             msh = load(joinpath(tf, "cube.obj")) # quads
             @test length(faces(msh)) == 12
             @test length(vertices(msh)) == 8
+            test_face_indices(msh)
 
             msh = load(joinpath(tf, "polygonal_face.obj"))
             @test length(faces(msh)) == 4
             @test length(vertices(msh)) == 6
+            test_face_indices(msh)
 
             msh = load(joinpath(tf, "test_face_normal.obj"))
             @test length(faces(msh)) == 1
             @test length(vertices(msh)) == 3
+            test_face_indices(msh)
 
         end
         @testset "2DM" begin
             msh = load(joinpath(tf, "test.2dm"))
             @test typeof(msh) == GLNormalMesh
+            test_face_indices(msh)
             #@test length(faces(msh)) == 3954
             #@test length(vertices(msh)) == 2248
             #@test length(normals(msh)) == 2248

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using FileIO, GeometryTypes
-using Base.Test
+using Test
 const tf = joinpath(dirname(@__FILE__), "testfiles")
 
 @testset "MeshIO" begin


### PR DESCRIPTION
This fixes all deprecation warnings on Julia v0.7, and updates the minimum Julia version to v0.7-alpha. 

All of the tests pass locally for me with StaticArrays master,  https://github.com/JuliaIO/FileIO.jl/pull/190 and https://github.com/JuliaGeometry/GeometryTypes.jl/pull/134 . We might want to wait until those get merged and tagged before merging this. 

I also added some more tests to try to make sure we don't have any OffsetInteger bugs. 