### PR TITLE
Fix 2dm `save`

### DIFF
--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -5,7 +5,7 @@ using ColorTypes
 using Printf
 import FileIO
 
-using GeometryBasics: raw, decompose_normals, convert_simplex
+using GeometryBasics: raw, value, decompose_normals, convert_simplex
 import FileIO: DataFormat, @format_str, Stream, File, filename, stream
 import FileIO: skipmagic, add_format
 

--- a/src/io/2dm.jl
+++ b/src/io/2dm.jl
@@ -22,11 +22,11 @@ function load(st::Stream{format"2DM"}; facetype=GLTriangleFace, pointtype=Point3
 end
 
 function print_face(io::IO, i::Int, f::TriangleFace)
-    println(io, "E3T $i ", join(Int.(f), " "))
+    println(io, "E3T $i ", join(Int.(value.(f)), " "))
 end
 
 function print_face(io::IO, i::Int, f::QuadFace)
-    println(io, "E4Q $i ", join(Int.(f), " "))
+    println(io, "E4Q $i ", join(Int.(value.(f)), " "))
 end
 
 # | Write @Mesh@ to an IOStream


### PR DESCRIPTION
OffsetInteger doesn't seem to be accepted by Int in newer release, so using GB.value to extract the value