### PR TITLE
Fix vertex remapping of obj files

### DIFF
--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -53,7 +53,7 @@ function load(io::Stream{format"OBJ"}; facetype=GLTriangleFace,
 
     N = length(points)
     non_empty_faces = filter(f -> !isempty(f), f_uv_n_faces)
-    void = tuple((one(eltype(facetype)) for _ in 1:length(non_empty_faces))...)
+    void = tuple((_typemax(eltype(facetype)) for _ in 1:length(non_empty_faces))...)
     vertices = fill(void, N)
 
     if !isempty(v_normals)
@@ -122,4 +122,8 @@ process_face_uv_or_normal(lines::Vector) = split.(lines, ('/',))
 function triangulated_faces(::Type{Tf}, vertex_indices::Vector) where {Tf}
     poly_face = NgonFace{length(vertex_indices), UInt32}(parse.(UInt32, vertex_indices))
     return convert_simplex(Tf, poly_face)
+end
+
+function _typemax(::Type{OffsetInteger{O, T}}) where {O, T}
+    typemax(T)
 end

--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -51,15 +51,16 @@ function load(io::Stream{format"OBJ"}; facetype=GLTriangleFace,
     end
     point_attributes = Dict{Symbol, Any}()
 
+    N = length(points)
     non_empty_faces = filter(f -> !isempty(f), f_uv_n_faces)
     void = tuple((one(eltype(facetype)) for _ in 1:length(non_empty_faces))...)
-    vertices = fill(void, length(points))
+    vertices = fill(void, N)
 
     if !isempty(v_normals)
-        point_attributes[:normals] = Vector{normaltype}(undef, length(points))
+        point_attributes[:normals] = Vector{normaltype}(undef, N)
     end
     if !isempty(uv)
-        point_attributes[:uv] = Vector{uvtype}(undef, length(points))
+        point_attributes[:uv] = Vector{uvtype}(undef, N)
     end
 
     for (k, fs) in enumerate(zip(non_empty_faces...))
@@ -83,7 +84,7 @@ function load(io::Stream{format"OBJ"}; facetype=GLTriangleFace,
                 # vertex is correct, nothing to replace
                 f[i] = vertex[1]
             else
-                @views j = findfirst(==(vertex), vertices[length(points)+1:end])
+                @views j = findfirst(==(vertex), vertices[N+1:end])
                 if j === nothing
                     # vertex is unique, add it as a new one and adjust
                     # points, uv, normals
@@ -100,7 +101,7 @@ function load(io::Stream{format"OBJ"}; facetype=GLTriangleFace,
                 else
                     # vertex has already been added, adjust face
                     # (points, uv, normals correct because they've been pushed)
-                    f[i] = j + length(points)
+                    f[i] = j + N
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,8 +122,8 @@ end
         @testset "OBJ" begin
             msh = load(joinpath(tf, "test.obj"))
             @test length(faces(msh)) == 3954
-            @test length(coordinates(msh)) == 2248
-            @test length(normals(msh)) == 2248
+            @test length(coordinates(msh)) == 2519
+            @test length(normals(msh)) == 2519
             @test test_face_indices(msh)
 
             msh = load(joinpath(tf, "cube.obj")) # quads

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,8 +122,8 @@ end
         @testset "OBJ" begin
             msh = load(joinpath(tf, "test.obj"))
             @test length(faces(msh)) == 3954
-            @test length(coordinates(msh)) == 2519
-            @test length(normals(msh)) == 2519
+            @test length(coordinates(msh)) == 2520
+            @test length(normals(msh)) == 2520
             @test test_face_indices(msh)
 
             msh = load(joinpath(tf, "cube.obj")) # quads


### PR DESCRIPTION
Currently
```julia
catmesh = FileIO.load(GLMakie.assetpath("cat.obj"));
texture = FileIO.load(GLMakie.assetpath("diffusemap.tga"))
mesh(catmesh, color=texture)
```
looks wrong because the normal and uv remapping discards points. (Specifically points along the edges of the texture, where one position has two (or more) uv coordinates associated with it.) I fixed that by duplicating the vertices in question and adjusting faces accordingly.

Before:
![Screenshot from 2020-10-18 01-07-17](https://user-images.githubusercontent.com/10947937/97065975-977edb00-15b1-11eb-9415-65d790a1475f.png)

After:
![Screenshot from 2020-10-24 04-13-53](https://user-images.githubusercontent.com/10947937/97065980-9e0d5280-15b1-11eb-9238-ee5537b94cb4.png)
