### PR TITLE
Precompile: fail gently, update for FileIO 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 author = "Simon Danisch"
 name = "MeshIO"
 uuid = "7269a6da-0436-5bbc-96c2-40638cbb6118"
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,10 +1,31 @@
+macro warnpcfail(ex::Expr)
+    modl = __module__
+    file = __source__.file === nothing ? "?" : String(__source__.file)
+    line = __source__.line
+    quote
+        $(esc(ex)) || @warn """precompile directive
+     $($(Expr(:quote, ex)))
+ failed. Please report an issue in $($modl) (after checking for duplicates) or remove this directive.""" _file=$file _line=$line
+    end
+end
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    @assert precompile(load, (File{format"2DM"},))
-    @assert precompile(load, (File{format"MSH"},))
-    @assert precompile(load, (File{format"OBJ"},))
-    @assert precompile(load, (File{format"OFF"},))
-    @assert precompile(load, (File{format"PLY_ASCII"},))
-    @assert precompile(load, (File{format"STL_ASCII"},))
-    @assert precompile(load, (File{format"STL_BINARY"},))
+    if isdefined(FileIO, :action)
+        @warnpcfail precompile(load, (File{format"2DM",IOStream},))
+        @warnpcfail precompile(load, (File{format"MSH",IOStream},))
+        @warnpcfail precompile(load, (File{format"OBJ",IOStream},))
+        @warnpcfail precompile(load, (File{format"OFF",IOStream},))
+        @warnpcfail precompile(load, (File{format"PLY_ASCII",IOStream},))
+        @warnpcfail precompile(load, (File{format"STL_ASCII",IOStream},))
+        @warnpcfail precompile(load, (File{format"STL_BINARY",IOStream},))
+    else
+        @warnpcfail precompile(load, (File{format"2DM"},))
+        @warnpcfail precompile(load, (File{format"MSH"},))
+        @warnpcfail precompile(load, (File{format"OBJ"},))
+        @warnpcfail precompile(load, (File{format"OFF"},))
+        @warnpcfail precompile(load, (File{format"PLY_ASCII"},))
+        @warnpcfail precompile(load, (File{format"STL_ASCII"},))
+        @warnpcfail precompile(load, (File{format"STL_BINARY"},))
+    end
 end


### PR DESCRIPTION
This changes failure in precompilation to a warning rather than an error.