### PR TITLE
Replace Vec3f0 with Vec3f, FRect3D with Rect3f

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
-author = "Simon Danisch"
 name = "MeshIO"
 uuid = "7269a6da-0436-5bbc-96c2-40638cbb6118"
+author = "Simon Danisch"
 version = "0.4.7"
 
 [deps]
@@ -12,7 +12,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [compat]
 ColorTypes = "0.8, 0.9, 0.10, 0.11"
 FileIO = "1.2.4"
-GeometryBasics = "0.3.3"
+GeometryBasics = "0.4.1"
 julia = "1.4"
 
 [extras]

--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -19,8 +19,8 @@ include("io/2dm.jl")
 include("io/msh.jl")
 
 """
-    load(fn::File{MeshFormat}; pointtype=Point3f0, uvtype=Vec2f0,
-         facetype=GLTriangleFace, normaltype=Vec3f0)
+    load(fn::File{MeshFormat}; pointtype=Point3f, uvtype=Vec2f,
+         facetype=GLTriangleFace, normaltype=Vec3f)
 
 """
 function load(fn::File{format}; element_types...) where {format}

--- a/src/io/2dm.jl
+++ b/src/io/2dm.jl
@@ -1,5 +1,5 @@
 # | Read a .2dm (SMS Aquaveo) mesh-file and construct a @Mesh@
-function load(st::Stream{format"2DM"}; facetype=GLTriangleFace, pointtype=Point3f0)
+function load(st::Stream{format"2DM"}; facetype=GLTriangleFace, pointtype=Point3f)
     faces = facetype[]
     vertices = pointtype[]
     io = stream(st)
@@ -8,7 +8,7 @@ function load(st::Stream{format"2DM"}; facetype=GLTriangleFace, pointtype=Point3
             line = chomp(line)
             w = split(line)
             if w[1] == "ND"
-                push!(vertices, Point3f0(parse.(Float32, w[3:end])))
+                push!(vertices, Point3f(parse.(Float32, w[3:end])))
             elseif w[1] == "E3T"
                 push!(faces, GLTriangleFace(parse.(Cuint, w[3:5])))
             elseif w[1] == "E4Q"

--- a/src/io/msh.jl
+++ b/src/io/msh.jl
@@ -1,6 +1,6 @@
 @enum MSHBlockType MSHFormatBlock MSHNodesBlock MSHElementsBlock MSHUnknownBlock
 
-function load(fs::Stream{format"MSH"}; facetype=GLTriangleFace, pointtype=Point3f0)
+function load(fs::Stream{format"MSH"}; facetype=GLTriangleFace, pointtype=Point3f)
     #GMSH MSH format (version 4)
     #http://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format
     io = stream(fs)

--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -5,7 +5,7 @@
 ##############################
 
 function load(io::Stream{format"OBJ"}; facetype=GLTriangleFace,
-        pointtype=Point3f0, normaltype=Vec3f0, uvtype=Vec2f0)
+        pointtype=Point3f, normaltype=Vec3f, uvtype=Vec2f)
 
     points, v_normals, uv, faces = pointtype[], normaltype[], uvtype[], facetype[]
     f_uv_n_faces = (faces, GLTriangleFace[], GLTriangleFace[])
@@ -23,12 +23,12 @@ function load(io::Stream{format"OBJ"}; facetype=GLTriangleFace,
             if "v" == command # mesh always has vertices
                 push!(points, Point{3, Float32}(parse.(Float32, lines))) # should automatically convert to the right type in vertices(mesh)
             elseif "vn" == command
-                push!(v_normals, Vec3f0(parse.(Float32, lines)))
+                push!(v_normals, Vec3f(parse.(Float32, lines)))
             elseif "vt" == command
                 if length(lines) == 2
-                    push!(uv, Vec2f0(parse.(Float32, lines)))
+                    push!(uv, Vec2f(parse.(Float32, lines)))
                 elseif length(lines) == 3
-                    push!(uv, Vec3f0(parse.(Float32, lines)))
+                    push!(uv, Vec3f(parse.(Float32, lines)))
                 else
                     error("Unknown UVW coordinate: $lines")
                 end
@@ -140,7 +140,7 @@ end
 
 function save(f::Stream{format"OBJ"}, mesh::AbstractMesh)
     io = stream(f)
-    for p in decompose(Point3f0, mesh)
+    for p in decompose(Point3f, mesh)
         println(io, "v ", p[1], " ", p[2], " ", p[3])
     end
 

--- a/src/io/off.jl
+++ b/src/io/off.jl
@@ -32,7 +32,7 @@ function save(str::Stream{format"OFF"}, msh::AbstractMesh)
     close(io)
 end
 
-function load(st::Stream{format"OFF"}; facetype=GLTriangleFace, pointtype=Point3f0)
+function load(st::Stream{format"OFF"}; facetype=GLTriangleFace, pointtype=Point3f)
     io = stream(st)
     points = pointtype[]
     faces = facetype[] # faces might be triangulated, so we can't assume count

--- a/src/io/ply.jl
+++ b/src/io/ply.jl
@@ -52,7 +52,7 @@ function save(f::Stream{format"PLY_ASCII"}, msh::AbstractMesh)
     close(io)
 end
 
-function load(fs::Stream{format"PLY_ASCII"}; facetype=GLTriangleFace, pointtype=Point3f0)
+function load(fs::Stream{format"PLY_ASCII"}; facetype=GLTriangleFace, pointtype=Point3f)
     io = stream(fs)
     n_points = 0
     n_faces = 0

--- a/src/io/stl.jl
+++ b/src/io/stl.jl
@@ -1,6 +1,6 @@
 function save(f::Stream{format"STL_ASCII"}, mesh::AbstractMesh)
     io = stream(f)
-    points = decompose(Point3f0, mesh)
+    points = decompose(Point3f, mesh)
     faces = decompose(GLTriangleFace, mesh)
     normals = decompose_normals(mesh)
 
@@ -32,7 +32,7 @@ show(io::IO, ::MIME"model/stl+ascii", mesh::AbstractMesh) = save(io, mesh)
 
 function save(f::Stream{format"STL_BINARY"}, mesh::AbstractMesh)
     io = stream(f)
-    points = decompose(Point3f0, mesh)
+    points = decompose(Point3f, mesh)
     faces = decompose(GLTriangleFace, mesh)
     normals = decompose_normals(mesh)
     n_faces = length(faces)
@@ -56,7 +56,7 @@ end
 
 
 function load(fs::Stream{format"STL_BINARY"}; facetype=GLTriangleFace,
-              pointtype=Point3f0, normaltype=Vec3f0)
+              pointtype=Point3f, normaltype=Vec3f)
     #Binary STL
     #https://en.wikipedia.org/wiki/STL_%28file_format%29#Binary_STL
     io = stream(fs)
@@ -90,7 +90,7 @@ end
 
 
 function load(fs::Stream{format"STL_ASCII"}; facetype=GLTriangleFace,
-              pointtype=Point3f0, normaltype=Vec3f0, topology=false)
+              pointtype=Point3f, normaltype=Vec3f, topology=false)
     #ASCII STL
     #https://en.wikipedia.org/wiki/STL_%28file_format%29#ASCII_STL
     io = stream(fs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,9 +17,9 @@ end
     dirlen = 1f0
     baselen = 0.02f0
     mesh = [
-        FRect3D(Vec3f0(baselen), Vec3f0(dirlen, baselen, baselen)),
-        FRect3D(Vec3f0(baselen), Vec3f0(baselen, dirlen, baselen)),
-        FRect3D(Vec3f0(baselen), Vec3f0(baselen, baselen, dirlen))
+        Rect3f(Vec3f(baselen), Vec3f(dirlen, baselen, baselen)),
+        Rect3f(Vec3f(baselen), Vec3f(baselen, dirlen, baselen)),
+        Rect3f(Vec3f(baselen), Vec3f(baselen, baselen, dirlen))
     ]
     uvn_mesh = merge(map(uv_normal_mesh, mesh))
     mesh = merge(map(triangle_mesh, mesh))


### PR DESCRIPTION
This switches to new GeometryBasics type names from JuliaGeometry/GeometryBasics.jl#97.