### PR TITLE
Support Julia 1.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.4'
+          - '1.3'
           - '1.6'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshIO"
 uuid = "7269a6da-0436-5bbc-96c2-40638cbb6118"
 author = "Simon Danisch"
-version = "0.4.8"
+version = "0.4.9"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -13,7 +13,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ColorTypes = "0.8, 0.9, 0.10, 0.11"
 FileIO = "1.2.4"
 GeometryBasics = "0.4.1"
-julia = "1.4"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -3,11 +3,9 @@ module MeshIO
 using GeometryBasics
 using ColorTypes
 using Printf
-import FileIO
 
 using GeometryBasics: raw, value, decompose_normals, convert_simplex
-import FileIO: DataFormat, @format_str, Stream, File, filename, stream
-import FileIO: skipmagic, add_format
+using FileIO: FileIO, @format_str, Stream, File, stream, skipmagic
 
 import Base.show
 

--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -41,4 +41,14 @@ if Base.VERSION >= v"1.4.2"
     _precompile_()
 end
 
+# `filter(f, ::Tuple)` is not available on Julia 1.3
+# https://github.com/JuliaLang/julia/pull/29259
+function filtertuple(f, xs::Tuple)
+    return @static if VERSION < v"1.4.0-DEV.551"
+        Base.afoldl((ys, x) -> f(x) ? (ys..., x) : ys, (), xs...)
+    else
+        filter(f, xs)
+    end
+end
+
 end # module

--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -51,7 +51,7 @@ function load(io::Stream{format"OBJ"}; facetype=GLTriangleFace,
     end
 
     point_attributes = Dict{Symbol, Any}()
-    non_empty_faces = filter(f -> !isempty(f), f_uv_n_faces)
+    non_empty_faces = filtertuple(!isempty, f_uv_n_faces)
 
     if length(non_empty_faces) > 1
         N = length(points)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,17 +34,17 @@ end
             end
         end
         @testset "PLY ascii and binary" begin
-            f = File(format"PLY_ASCII", joinpath(tmpdir, "test.ply"))
+            f = File{format"PLY_ASCII"}(joinpath(tmpdir, "test.ply"))
             save(f, mesh)
             mesh_loaded = load(joinpath(tmpdir, "test.ply"))
             @test mesh_loaded == mesh
-            save(File(format"PLY_BINARY", joinpath(tmpdir, "test.ply")), mesh)
+            save(File{format"PLY_BINARY"}(joinpath(tmpdir, "test.ply")), mesh)
         end
         @testset "STL ascii and binary" begin
-            save(File(format"STL_ASCII", joinpath(tmpdir, "test.stl")), mesh)
+            save(File{format"STL_ASCII"}(joinpath(tmpdir, "test.stl")), mesh)
             mesh_loaded = load(joinpath(tmpdir, "test.stl"))
             @test Set(mesh.position) == Set(mesh_loaded.position)
-            save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), mesh)
+            save(File{format"STL_BINARY"}(joinpath(tmpdir, "test.stl")), mesh)
             mesh_loaded = load(joinpath(tmpdir, "test.stl"))
             @test Set(mesh.position) == Set(mesh_loaded.position)
         end
@@ -71,7 +71,7 @@ end
             @test test_face_indices(msh)
 
             mktempdir() do tmpdir
-                save(File(format"STL_BINARY", joinpath(tmpdir, "test.stl")), msh)
+                save(File{format"STL_BINARY"}(joinpath(tmpdir, "test.stl")), msh)
                 msh1 = load(joinpath(tmpdir, "test.stl"))
                 @test msh1 isa GLNormalMesh
                 @test faces(msh) == faces(msh1)


### PR DESCRIPTION
MeshIO holds back GeometryBasics (and hence also GridLayoutBase) in the tests of Makie with Julia 1.3 (https://github.com/JuliaPlots/Makie.jl/pull/1244). CI should reveal any potential issues with Julia 1.3 🙂