### PR TITLE
Fix index remapping

### DIFF
--- a/src/MeshIO.jl
+++ b/src/MeshIO.jl
@@ -9,6 +9,8 @@ using FileIO: FileIO, @format_str, Stream, File, stream, skipmagic
 
 import Base.show
 
+include("util.jl")
+
 include("io/off.jl")
 include("io/ply.jl")
 include("io/stl.jl")

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,56 @@
+# Graphics backends like OpenGL only have one index buffer so the indices to
+# positions, normals and texture coordinates cannot be different. E.g. a face
+# cannot use positional indices (1, 2, 3) and normal indices (1, 1, 2). In that
+# case we need to remap normals such that new_normals[1, 2, 3] = normals[[1, 1, 2]]
+
+
+# ...
+_typemin(x) = typemin(x)
+_typemin(::Type{OffsetInteger{N, T}}) where {N, T} = typemin(T) - N
+
+merge_vertex_attribute_indices(faces...) = merge_vertex_attribute_indices(faces)
+
+function merge_vertex_attribute_indices(faces::Tuple)
+    FaceType = eltype(faces[1])
+    IndexType = eltype(FaceType)
+    D = length(faces)
+    N = length(faces[1])
+
+    # (pos_idx, normal_idx, uv_idx, ...) -> new_idx
+    vertex_index_map = Dict{NTuple{D, UInt32}, IndexType}()
+    # faces after remapping (0 based assumed)
+    new_faces = sizehint!(FaceType[], N)
+    temp = IndexType[]           # keeping track of vertex indices of a face
+    counter = _typemin(IndexType)
+    # for remaping attribs, i.e. `new_attrib = old_attrib[index2vertex[attrib_index]]`
+    index2vertex = ntuple(_ -> sizehint!(UInt32[], N), D)
+
+    for i in eachindex(faces[1])
+        # (pos_faces[i], normal_faces[i], uv_faces[i], ...)
+        attrib_faces = getindex.(faces, i)
+        empty!(temp)
+        
+        for j in eachindex(attrib_faces[1])
+            # (pos_index, normal_idx, uv_idx, ...)
+            # = (pos_faces[i][j], normal_faces[i][j], uv_faces[i][j], ...)
+            vertex = GeometryBasics.value.(getindex.(attrib_faces, j)) # 1 based
+
+            # if combination of indices in vertex is new, make a new index
+            if !haskey(vertex_index_map, vertex)
+                vertex_index_map[vertex] = counter
+                counter = IndexType(counter + 1)
+                push!.(index2vertex, vertex)
+            end
+
+            # keep track of the (new) index for this vertex
+            push!(temp, vertex_index_map[vertex])
+        end
+
+        # store face with new indices
+        push!(new_faces, FaceType(temp...))
+    end
+
+    sizehint!(new_faces, length(new_faces))
+
+    return new_faces, index2vertex
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,5 +176,25 @@ end
             #@test typeof(msh) == GLNormalMesh
             #test_face_indices(msh)
         end
+
+        @testset "Index remapping" begin
+            pos_faces    = GLTriangleFace[(5, 6, 7), (5, 6, 8), (5, 7, 8)]
+            normal_faces = GLTriangleFace[(5, 6, 7), (3, 6, 8), (5, 7, 8)]
+            uv_faces     = GLTriangleFace[(1, 2, 3), (4, 2, 5), (1, 3, 1)]
+            
+            #   unique combinations    ->      new indices
+            # 551 662 773 534 885 881      1 2 3 4 5 6 (or 0..5 with 0 based indices)
+            faces, maps = MeshIO.merge_vertex_attribute_indices(pos_faces, normal_faces, uv_faces)
+
+            @test length(faces) == 3
+            @test faces == GLTriangleFace[(1, 2, 3), (4, 2, 5), (1, 3, 6)]
+
+            # maps are structured as map[new_index] = old_index, so they grab the
+            # first/second/third index of the unique combinations above
+            # maps = (pos_map, normal_map, uv_map)
+            @test maps[1] == [5, 6, 7, 5, 8, 8]
+            @test maps[2] == [5, 6, 7, 3, 8, 8]
+            @test maps[3] == [1, 2, 3, 4, 5, 1]
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,8 +133,8 @@ end
         @testset "OBJ" begin
             msh = load(joinpath(tf, "test.obj"))
             @test length(faces(msh)) == 3954
-            @test length(coordinates(msh)) == 2520
-            @test length(normals(msh)) == 2520
+            @test length(coordinates(msh)) == 2519
+            @test length(normals(msh)) == 2519
             @test test_face_indices(msh)
 
             msh = load(joinpath(tf, "cube.obj")) # quads


### PR DESCRIPTION
While trying to fix https://github.com/MakieOrg/Makie.jl/pull/3993 I noticed that you get an uninitialized normal (and probably position) when loading the cat mesh (test.obj here). This is due to the index remapping not working correctly. (As a reminder - object files can specify independent indices for positions, normals and texture coordinates within a vertex of a face. OpenGL only allows one index buffer, i.e. one index per vertex, so we need to combine vertex indices into a single unique index and reorder the position, normal and texture coordinate arrays accordingly.)

To fix this I just rewrote the remapping code with a `Dict` instead of whatever it was doing. That should make it faster and easier to understand/reason with. In the end this removes one position and normal from the cat mesh which should be that undefined first normal/position. I also added a short test for the remapping function.