### PR TITLE
Add support for materials in obj files

### DIFF
--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -353,11 +353,12 @@ function _load_mtl!(materials::Dict{String, Dict{String, Any}}, filename::String
     return materials
 end
 
+# TODO: Consider generating a ShaderAbstractions Sampler?
 function parse_texture_info(parent_path::String, lines::Vector{SubString{String}})
     idx = 1
     output = Dict{String, Any}()
     name_lookup = Dict(
-        "o" => "origin offset", "s" => "scale", "t" => "turbulence",
+        "o" => "offset", "s" => "scale", "t" => "turbulence",
         "blendu" => "blend horizontal", "blendv" => "blend vertical",
         "boost" => "mipmap sharpness", "bm" => "bump multiplier"
     )


### PR DESCRIPTION
Replacement for #95 after #97 is merged.
Tests pass with warnings locally due to missing cube.mtl

Example from #95 becomes:
```julia
using FileIO, MeshIO, GeometryBasics
path = "..."
filepath = joinpath(path, "14-girl-obj/girl OBJ.obj")
mesh = load(filepath)

meshes = GeometryBasics.split_mesh(mesh.mesh)
# filename incorrect in mtl file...?
mesh[:materials]["FACE"]["diffuse map"]["filename"] = "D:/data/Julia/14-girl-obj/tEXTURE/FACE Base Color apha.png"

using GLMakie

begin
    fig = Figure()
    ax = LScene(fig[1, 1])

    for (i, m) in enumerate(meshes)
        # get material associated with a submesh
        material_name = mesh[:material_names][i]
        material = mesh[:materials][material_name]

        # load texture from filename specified in .mtl file
        texture = try
            load(material["diffuse map"]["filename"])
        catch
            RGBf(0,1,0)
        end

        # texture uses white as transparent for some reason...
        if material_name == "FACE"
            texture = map(texture) do c
                RGBAf(c.r, c.g, c.b, 1 - c.r)
            end
        end

        # render mesh with specified material properties if specified
        mesh!(ax, m, color = texture,
            diffuse = get(material, "diffuse", Vec3f(1)),
            specular = get(material, "specular", Vec3f(0.2)),
            shininess = get(material, "shininess", 32f0),
        )
    end

    fig
end
```