### PR TITLE
Remove ascii check in obj file parsing

### DIFF
--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -30,7 +30,6 @@ function load(fn::File{format"OBJ"}; facetype=GLTriangleFace,
         for full_line in eachline(stream(io))
             # read a line, remove newline and leading/trailing whitespaces
             line = strip(chomp(full_line))
-            !isascii(line) && error("non valid ascii in obj")
 
             if !startswith(line, "#") && !isempty(line) && !all(iscntrl, line) #ignore comments
                 lines = split(line)


### PR DESCRIPTION
Fixes #101 by removing the ascii check. We're not indexing the string directly so I don't see why we couldn't allow unicode. The check has been there since the initial version (Julia ~0.4) of this file (as `isvalid()`) so it doesn't seem like it's been introduced to fix anything specific.