### PR TITLE
Switched to using warning when mtl file is missing

### DIFF
--- a/src/io/obj.jl
+++ b/src/io/obj.jl
@@ -154,7 +154,7 @@ function load(fn::File{format"OBJ"}; facetype=GLTriangleFace,
 
         # Fallback - if no mtl file exists abort and return just the mesh
         if !any(filename -> isfile(joinpath(path, filename)), mtllibs)
-            @error "obj file contains references to .mtl files, but none could be found. Expected: $mtllibs in $path."
+            @warn "obj file contains references to .mtl files, but none could be found. Expected: $mtllibs in $path."
             return mesh
         end
 


### PR DESCRIPTION
It is quite common for OBJ files to not have an MTL file. Currently `obj.jl` throws an error when no MTL file is encountered. Given how often OBJ files lack an MTL file and that it is not a requirement for an OBJ to be valid, I here propose to simply replace `@error` with `@warn`.  

Having this as a warning lets one suppress the warning and still not suppress the other errors which do seem like important errors. 

I would also be in favour of just removing the warning/error all together but that might be a discussion for another day :)